### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kaeser-sc2-api",
-  "version": "0.2.2",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kaeser-sc2-api",
-      "version": "0.2.2",
+      "version": "0.3.2",
       "license": "GPLv3",
       "dependencies": {
         "@narando/nest-axios-interceptor": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaeser-sc2-api",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Kaeser Sigma Control 2 API",
   "author": "Paul Sites <paul@brownindustries.com>",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump package version from 0.3.1 to 0.3.2 after the compressor session retry fix.
- Update package-lock metadata to match the release version.

## Validation
- `git diff --check`
- `npm test -- --runInBand`
- `npm run build`

## Notes
`main` is protected and requires CODEOWNER approval from `@pts211`, so this PR should route the production version bump through review.